### PR TITLE
added default api jet cred

### DIFF
--- a/development_env_file
+++ b/development_env_file
@@ -1,3 +1,0 @@
-POSTGRES_USER=pass_culture
-POSTGRES_PASSWORD=passq
-POSTGRES_DB=pass_culture

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
         read_only: true
     environment:
       - ENV=${ENV:-development}
+      - EXPORT_TOKEN=$EXPORT_TOKEN
       - MAILJET_API_KEY=${MAILJET_API_KEY:-20594a94ba962e549a7d5b1c3c6cd1ce}
       - MAILJET_API_SECRET=${MAILJET_API_SECRET:-9c55d1afb02b90e9150b316dc50a8dd6}
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,14 +18,12 @@ services:
         source: ./api/ftp_mirrors
         target: /opt/services/flaskapp/src/ftp_mirrors
         read_only: true
-    env_file:
-      - env_file
-      - ${ENV:-development}_env_file
     environment:
       - ENV=${ENV:-development}
-      - EXPORT_TOKEN=$EXPORT_TOKEN
-      - MAILJET_API_KEY=$MAILJET_API_KEY
-      - MAILJET_API_SECRET=$MAILJET_API_SECRET
+      - MAILJET_API_KEY=${MAILJET_API_KEY:-20594a94ba962e549a7d5b1c3c6cd1ce}
+      - MAILJET_API_SECRET=${MAILJET_API_SECRET:-9c55d1afb02b90e9150b316dc50a8dd6}
+    env_file:
+      - env_file
     networks:
       - db_nw
       - web_nw

--- a/dockerfiles/flask/start_python.sh
+++ b/dockerfiles/flask/start_python.sh
@@ -2,7 +2,7 @@
 set -x
 cd /opt/services/flaskapp/src
 pip install -r requirements.txt
-sleep 3 # This leaves time for Postgres to create the DB
+sleep 10 # This leaves time for Postgres to create the DB
 while true; do
     python app.py
     sleep 2


### PR DESCRIPTION
@augnustin 
csi jamais tu veux faire marcher les bookings en DEV, 
la facon simple de setter les variables d'env pour mail jet c'est de faire comme ici:
les ajouter en default au docker-compose.
(ou tu te les mets dans ton .procfile un truc comme ca)