### PR TITLE
Add tests for pc with bats-mock

### DIFF
--- a/pc
+++ b/pc
@@ -12,7 +12,7 @@ where:
     -e  specify environment to target (default: development)
     -b  specify backend to connect with local app (default: localhost)
     -t  specify version you want to deploy (create tag with this name)
-    c   command that you want to run"
+    -c  command that you want to run"
     exit 0
 fi
 
@@ -37,13 +37,16 @@ fi
 
 if [[ $# -gt 2 ]] && [[ "$1" == "-t" ]]; then
 
-  if [[ "$2" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+  if [[ "$2" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
     TAG_NAME=$2
   else
-    echo "tag format should be Semantic Versioning compliant (vx.x.x)"
+    echo "tag format should be Semantic Versioning compliant x.x.x"
+    exit 1
   fi
 
   shift 2
+else
+  TAG_NAME=${TAG_NAME:-'not-set'}
 fi
 
 CMD="$1"
@@ -64,6 +67,10 @@ fi
 # =============================================
 # Utilities functions
 # =============================================
+RED='\033[0;31m'
+ORANGE='\033[0;33m'
+NO_COLOR='\033[0m'
+
 PRG="$BASH_SOURCE"
 
 while [ -h "$PRG" ] ; do
@@ -94,12 +101,21 @@ function ensure_remote {
   fi
 }
 
+function echo_error {
+  echo -e "${RED}""$1""${NO_COLOR}"
+}
+
+function echo_warning {
+  echo -e "${ORANGE}""$1""${NO_COLOR}"
+}
+
+
 current_branch=$(git symbolic-ref -q HEAD)
 current_branch=${current_branch##refs/heads/}
 
 function exit_restoring_branch {
   git checkout "$current_branch"
-  exit
+  exit 1
 }
 
 # =============================================
@@ -251,14 +267,27 @@ elif [[ "$CMD" == "deploy-backend" ]] \
      || [[ "$CMD" == "deploy-frontend-webapp" ]] \
      || [[ "$CMD" == "deploy-frontend-pro" ]]; then
 
-  ensure_remote "Deploy backend cannot be run on the local environment. Use (for example) \"pc -e staging "$CMD"\"."
+  ensure_remote "Deploy backend cannot be run on the local environment. Use (for example) \"pc -e staging -t X.Y.Z "$CMD"\"."
 
   if [[ ! "$ENV" == 'production' ]] \
         && [[ ! "$ENV" == 'staging' ]] \
         && [[ ! "$ENV" == 'demo' ]] \
+        && [[ ! "$ENV" == 'bats-tests' ]] \
         && [[ ! "$ENV" == 'integration' ]]; then
-     echo "Can only deploy-backend in staging, demo, integration and production"
-     exit
+     echo_error "Can only deploy-backend in staging, demo, integration and production"
+     exit 1
+  fi
+
+  if [[ "$TAG_NAME" == 'not-set' ]]; then
+    echo_error "ERROR: You need to specify an existing tag to deploy"
+    exit_restoring_branch
+  fi
+
+  if [[ ! -z $(git ls-remote --tags origin refs/tags/v"$TAG_NAME") ]]; then
+    git checkout "v$TAG_NAME"
+  else
+    echo_error "ERROR: You need to specify an existing remote tag to deploy"
+    exit_restoring_branch
   fi
 
   if [[ "$CMD" == "deploy-frontend-webapp"  ]]; then
@@ -270,38 +299,34 @@ elif [[ "$CMD" == "deploy-backend" ]] \
   fi
 
   cd "$APP_PATH"
+  echo "$current_branch will be deployed to $ENV"
+  commit_to_deploy=$(git log -n 1 --pretty=format:%H)
 
   git fetch
   git checkout master
-  git pull || exit_restoring_branch
+  git pull origin master || exit_restoring_branch
+  git checkout bats-tests
+  git pull origin bats-tests || exit_restoring_branch
   git checkout staging
-  git pull || exit_restoring_branch
+  git pull origin staging || exit_restoring_branch
   git checkout demo
-  git pull || exit_restoring_branch
+  git pull origin demo || exit_restoring_branch
   git checkout integration
-  git pull || exit_restoring_branch
+  git pull origin integration || exit_restoring_branch
   git checkout production
-  git pull || exit_restoring_branch
-
-  if [[ "$TAG_VERSION" ]] \
-    && [[ ! -z $(git ls-remote --tags origin refs/tags/"$TAG_VERSION") ]]; then
-    git checkout "v$TAG_VERSION"
-  else
-    echo "ERROR: You need to specify an existing tag to deploy"
-    exit_restoring_branch
-  fi
-
-  commit_to_deploy=$(git log -n 1 --pretty=format:%H)
+  git pull origin production || exit_restoring_branch
 
   if [[ $(git tag -l --points-at "$commit_to_deploy" | wc -l) == 0 ]]; then
-    echo "ERROR: Can only deploy tagged commits"
+    echo_error "ERROR: Can only deploy tagged commits"
     exit_restoring_branch
   fi
 
-  if [[ "$ENV" == "production" ]]; then
+  if [[ "$ENV" == "production" ]] \
+    || [[ "$ENV" == "bats-tests" ]]; then
     staging_commit=$(git log -n 1 --pretty=format:%H staging)
+    echo "$staging_commit"
     if [[ "$staging_commit" != "$commit_to_deploy" ]]; then
-      echo "ERROR: Can only deploy in production commits that are also deployed in staging"
+      echo_error "ERROR: Can only deploy in production commits that are also deployed in staging"
       exit_restoring_branch
     fi
   fi
@@ -312,13 +337,20 @@ elif [[ "$CMD" == "deploy-backend" ]] \
 
   if [[ "$CMD" == "deploy-frontend-webapp" ]] \
      || [[ "$CMD" == "deploy-frontend-pro" ]]; then
-    (set -a; source "$APP_PATH/node_modules/pass-culture-shared/config/run_envs/$ENV" && yarn build) || exit
-     ./"$APP_PATH"/scripts/build_redirects.sh
-    netlify deploy -e "$ENV"
+     rm -rf "$APP_PATH"/node_modules "$APP_PATH"/build "$APP_PATH"/public/static/fontello/.fontello.session && yarn install
+     (set -a; source "$APP_PATH/node_modules/pass-culture-shared/config/run_envs/$ENV" && yarn build) || exit
+
+     url_is_set=$(cat build/static/js/*.js | grep -E backend.passculture*.beta.gouv.fr)
+     if [ -z "$url_is_set" ]; then
+        echo_error "URL not found in build artifact. Problem with environment variables"
+        exit_restoring_branch
+     fi
+     netlify deploy -e "$ENV"
   fi
 
-  if [[ "$ENV" == 'production' ]]; then
-     echo "/!\\ You just deployed to production. Was the version also delivered to integration ?"
+  if [[ "$ENV" == 'production' ]]\
+    || [[ "$ENV" == "bats-tests" ]]; then
+     echo_warning "/!\\ You just deployed to production. Was the version also delivered to integration ?"
   fi
 
   exit_restoring_branch

--- a/tests/pc_deploy.bats
+++ b/tests/pc_deploy.bats
@@ -1,0 +1,229 @@
+#!./test/libs/bats/bin/bats
+
+load bats-mock/src/bats-mock
+
+debug_mock() {
+  # Debug
+  # Use the below line if you actually want to see all the arguments the function used to call the 'stub'
+  index=1
+  while [ $index -le $(mock_get_call_num ${mock}) ]
+  do
+    echo "# call_args: " $(mock_get_call_args ${mock} $index) >&3
+    index=$((index+1))
+  done
+}
+
+
+
+
+teardown() {
+    # Cleanup our stub and fixup the PATH
+    unlink "${mock_path}/${mocked_command}"
+    PATH="${PATH/${mock_path}:/}"
+}
+
+
+create_mock_for_test_1() {
+    mock="$(mock_create)"
+    mock_path="${mock%/*}"
+    mock_file="${mock##*/}"
+    ln -sf "${mock_path}/${mock_file}" "${mock_path}/${mocked_command}"
+    PATH="${mock_path}:$PATH"
+
+    # call with param: symbolic-ref -q HEAD
+    mock_set_output "${mock}" "bats-tests" 1
+    # call with param: ls-remote --tags origin refs/tags/v0.0.0
+    mock_set_output "${mock}" "" 2
+    # call with param: checkout bats-tests (function exit_restoring_branch)
+    mock_set_output "${mock}" "ok" 3
+}
+
+@test "1 - Deploy-backend on known environment with local tag but not existing remotely is not allowed" {
+  # Given
+  expected_output='ERROR: You need to specify an existing remote tag to deploy'
+  mocked_command="git"
+
+  create_mock_for_test_1
+
+  # Test mock is set up properly
+  [[ "$(readlink -e $(which git))" == "$(readlink -e ${mock})" ]]
+
+  # When
+  run pc -e bats-tests -t 0.0.0 deploy-backend
+
+  # Then
+  echo "$(mock_get_call_num ${mock})"
+  [[ "$(mock_get_call_num ${mock})" -eq 3 ]]
+
+  echo "Status: ""$status"
+  [ "$status" -eq 1 ]
+
+  echo "Expected: ""$expected_output"
+  echo "Output: ""${lines[0]}"
+  [[ "${lines[0]}" =~ .*$expected_output.* ]]
+}
+
+
+create_mock_for_test_2() {
+    mock="$(mock_create)"
+    mock_path="${mock%/*}"
+    mock_file="${mock##*/}"
+    ln -sf "${mock_path}/${mock_file}" "${mock_path}/${mocked_command}"
+    PATH="${mock_path}:$PATH"
+
+    # call with param: symbolic-ref -q HEAD
+    mock_set_output "${mock}" "bats-tests" 1
+    # call with param: ls-remote --tags origin refs/tags/v0.0.0
+    mock_set_output "${mock}" "v0.0.0" 2
+    # call with param: checkout bats-tests (function exit_restoring_branch)
+    mock_set_output "${mock}" "exit_restoring_branch" 3
+    # $(git log -n 1 --pretty=format:%H)
+    mock_set_output "${mock}" "commit_hash" 4
+    # git fetch
+    mock_set_output "${mock}" "fetch" 5
+    # git checkout master
+    mock_set_output "${mock}" "checkout master" 6
+    # git pull origin master || exit_restoring_branch
+    mock_set_output "${mock}" "pull master" 7
+    # git checkout bats-tests
+    mock_set_output "${mock}" "checkout bats-tests" 8
+    # git pull origin bats-tests || exit_restoring_branch
+    mock_set_output "${mock}" "pull bats-tests" 9
+    # git checkout staging
+    mock_set_output "${mock}" "checkout staging" 10
+    # git pull origin staging || exit_restoring_branch
+    mock_set_output "${mock}" "pull staging" 11
+    # git checkout demo
+    mock_set_output "${mock}" "checkout demo" 12
+    # git pull origin demo || exit_restoring_branch
+    mock_set_output "${mock}" "pull demo" 13
+    # git checkout integration
+    mock_set_output "${mock}" "checkout integration" 14
+    # git pull origin integration || exit_restoring_branch
+    mock_set_output "${mock}" "pull integration" 15
+    # git checkout production
+    mock_set_output "${mock}" "checkout production" 16
+    # git pull origin production || exit_restoring_branch
+    mock_set_output "${mock}" "pull production" 17
+    # git tag -l --points-at "$commit_to_deploy" | wc -l
+    mock_set_output "${mock}" "blabla" 18
+    # git log -n 1 --pretty=format:%H staging
+    mock_set_output "${mock}" "pretty log" 19
+}
+
+
+@test "2 - Deploy-backend on known environment with valid tag but not deployed in staging is not allowed" {
+  # Given
+  index=0
+  expected_output='ERROR: Can only deploy in production commits that are also deployed in staging'
+  mocked_command="git"
+
+  create_mock_for_test_2
+
+  # Test mock is set up properly
+  [[ "$(readlink -e $(which git))" == "$(readlink -e ${mock})" ]]
+
+  # When
+  run pc -e bats-tests -t 0.0.0 deploy-backend
+
+  # Then
+  echo "$(mock_get_call_num ${mock})"
+  [[ "$(mock_get_call_num ${mock})" -eq 20 ]]
+
+  echo "Status: ""$status"
+  [ "$status" -eq 1 ]
+
+  # Allow to follow last steps
+  for index in ${!lines[@]}; do
+      echo "Output $index: ${lines[index]}"
+  done
+  index=$((index))
+  echo "Expected: ""$expected_output"
+  echo "Output: ${lines[index]}"
+  [[ "${lines[index]}" =~ .*$expected_output.* ]]
+}
+
+
+create_mock_for_test_3() {
+  mock="$(mock_create)"
+  mock_path="${mock%/*}"
+  mock_file="${mock##*/}"
+  ln -sf "${mock_path}/${mock_file}" "${mock_path}/${mocked_command}"
+  PATH="${mock_path}:$PATH"
+
+  # call with param: symbolic-ref -q HEAD
+  mock_set_output "${mock}" "bats-tests" 1
+  # call with param: ls-remote --tags origin refs/tags/v0.0.0
+  mock_set_output "${mock}" "v0.0.0" 2
+  # call with param: checkout bats-tests (function exit_restoring_branch)
+  mock_set_output "${mock}" "exit_restoring_branch" 3
+  # $(git log -n 1 --pretty=format:%H)
+  mock_set_output "${mock}" "commit_hash" 4
+  # git fetch
+  mock_set_output "${mock}" "fetch" 5
+  # git checkout master
+  mock_set_output "${mock}" "checkout master" 6
+  # git pull origin master || exit_restoring_branch
+  mock_set_output "${mock}" "pull master" 7
+  # git checkout bats-tests
+  mock_set_output "${mock}" "checkout bats-tests" 8
+  # git pull origin bats-tests || exit_restoring_branch
+  mock_set_output "${mock}" "pull bats-tests" 9
+  # git checkout staging
+  mock_set_output "${mock}" "checkout staging" 10
+  # git pull origin staging || exit_restoring_branch
+  mock_set_output "${mock}" "pull staging" 11
+  # git checkout demo
+  mock_set_output "${mock}" "checkout demo" 12
+  # git pull origin demo || exit_restoring_branch
+  mock_set_output "${mock}" "pull demo" 13
+  # git checkout integration
+  mock_set_output "${mock}" "checkout integration" 14
+  # git pull origin integration || exit_restoring_branch
+  mock_set_output "${mock}" "pull integration" 15
+  # git checkout production
+  mock_set_output "${mock}" "checkout production" 16
+  # git pull origin production || exit_restoring_branch
+  mock_set_output "${mock}" "pull production" 17
+  # git tag -l --points-at "$commit_to_deploy" | wc -l
+  mock_set_output "${mock}" "commit_hash" 18
+  # git log -n 1 --pretty=format:%H staging
+  mock_set_output "${mock}" "commit_hash" 19
+  # git checkout "$ENV"
+  mock_set_output "${mock}" "checkout ENV" 20
+  # git merge "$commit_to_deploy"
+  mock_set_output "${mock}" "merge" 21
+  # git push origin "$ENV"
+  mock_set_output "${mock}" "push ENV" 22
+}
+
+@test "3 - Deploy-backend on production environment" {
+  # Given
+  index=0
+  expected_output='/!\\ You just deployed to production. Was the version also delivered to integration ?'
+  mocked_command="git"
+
+  create_mock_for_test_3
+
+  # Test mock is set up properly
+  [[ "$(readlink -e $(which git))" == "$(readlink -e ${mock})" ]]
+
+  # When
+  run pc -e bats-tests -t 0.0.0 deploy-backend
+
+  # Then
+  echo "$(mock_get_call_num ${mock})"
+  [[ "$(mock_get_call_num ${mock})" -eq 23 ]]
+
+  for index in ${!lines[@]};
+  do
+    echo "Output $index: ${lines[index]}"
+  done
+
+  echo "Status: ""$status"
+  [ "$status" -eq 1 ]
+
+  echo "Expected: ""$expected_output"
+  echo "Output: ${lines[index]}"
+  [[ "${lines[index]}" =~ .*$expected_output.* ]]
+}

--- a/tests/pc_general.bats
+++ b/tests/pc_general.bats
@@ -1,0 +1,91 @@
+#!./test/libs/bats/bin/bats
+
+
+@test "Should show its usage when pc -h" {
+  # Given
+  input=""
+  expected_output="pc [-h] [-e env -b backend c] -- program to deal with Pass Culture ecosystem"
+
+  # When
+  run pc -h
+
+  # Then
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$expected_output" ]
+}
+
+
+
+@test "Deploy-backend should not be run if current $ENV is development" {
+    # Given
+    expected_output='Deploy backend cannot be run on the local environment. Use (for example) "pc -e staging -t X.Y.Z deploy-backend".'
+
+    # When
+    run pc deploy-backend
+
+    # Then
+
+    echo "Status: ""$status"
+    [ "$status" -eq 3 ]
+
+    echo "Expected: ""$expected_output"
+    echo "Output: ""${lines[0]}"
+    [ "${lines[0]}" == "$expected_output" ]
+}
+
+@test "Deploy-backend on unknown environment is not allowed" {
+    # Given
+    expected_output='Can only deploy-backend in staging, demo, integration and production'
+
+    # When
+    run pc -e unexisting-env deploy-backend
+
+    # Then
+
+    echo "Status: ""$status"
+    [ "$status" -eq 1 ]
+
+    echo "Expected: ""$expected_output"
+    echo "Output: ""${lines[0]}"
+    [[ "${lines[0]}" =~ .*$expected_output.* ]]
+}
+
+@test "Deploy-backend on known environment but with no tag is not allowed" {
+    # Given
+    environment=staging
+    expected_output='ERROR: You need to specify an existing tag to deploy'
+
+    # When
+    run pc -e $environment deploy-backend
+
+    # Then
+
+    echo "Status: ""$status"
+    [ "$status" -eq 1 ]
+
+    echo "Expected: ""$expected_output"
+    echo "Output: ""${lines[0]}"
+    [[ "${lines[0]}" =~ .*$expected_output.* ]]
+}
+
+@test "Deploy-backend on known environment with a malformed tag is not allowed" {
+    # Given
+    environment=staging
+    non_valid_tag='bats-tests'
+    expected_output='tag format should be Semantic Versioning compliant x.x.x'
+
+    # When
+    run pc -e $environment -t "$non_valid_tag" deploy-backend
+
+    # Then
+
+    echo "Status: ""$status"
+    [ "$status" -eq 1 ]
+
+    echo "Expected: ""$expected_output"
+    echo "Output: ""${lines[0]}"
+    [[ "${lines[0]}" =~ .*$expected_output.* ]]
+}
+
+
+

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+
+bats .
+rm /tmp/bats-mock.*


### PR DESCRIPTION
Premiers tests avec bats et bats-mock.
Pour exécuter les tests, il suffit d'installer bats (sudo npm install -g bats) et d'exécuter le script run_tests.sh
