### PR TITLE
Mettre le nom du volume plutôt qu'un chemin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   postgres:
     image: postgres:10.1
     volumes:
-      - "./api/postgres_data:/var/lib/postgresql/data"
+      - "postgres_data:/var/lib/postgresql/data"
     env_file:
       - env_file
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   postgres:
     image: postgres:10.1
     volumes:
-      - "postgres_data:/var/lib/postgresql/data"
+      - postgres_data:/var/lib/postgresql/data
     env_file:
       - env_file
     networks:

--- a/pc
+++ b/pc
@@ -195,7 +195,7 @@ elif [[ "$CMD" == "dump-db" ]]; then
 elif [[ "$CMD" == "rebuild-backend" ]]; then
   RUN='docker-compose build --no-cache;
 			 sudo rm -rf $ROOT_PATH/api/static/object_store_data;
-       sudo rm -rf $ROOT_PATH/api/postgres_data'
+       docker-compose down --volumes'
 
 # Execute request from specified file
 elif [[ "$CMD" == "psql-file" ]]; then
@@ -205,7 +205,7 @@ elif [[ "$CMD" == "psql-file" ]]; then
 # Restart API after removing the database and files
 elif [[ "$CMD" == "restart-backend" ]]; then
   RUN='sudo rm -rf $ROOT_PATH/api/static/object_store_data;
-       sudo rm -rf $ROOT_PATH/api/postgres_data;
+       docker-compose down --volumes;
        cd $ROOT_PATH && docker-compose up --force-recreate'
 
 # Clear all data in postgresql database


### PR DESCRIPTION
Avec mon WSL sous Windows, je n'arrivais pas à lancer `pc start-backend` dû, j'imagine, à une mauvaise gestion du chemin `./api/postgres_data`. Par conséquent, et c'est une bonne pratique, il vaut mieux utiliser le nom du volume directement, comme ça, Docker met son volume dans un répertoire à lui et il n'y a plus de problème d'environnement.
Pour plus de détails : https://docs.docker.com/compose/compose-file/#volume-configuration-reference